### PR TITLE
Show main card of mapinstances when empty

### DIFF
--- a/client/src/app/maps/page.tsx
+++ b/client/src/app/maps/page.tsx
@@ -17,7 +17,7 @@ import { useApp } from "@/contexts/AppContext";
 export default function Page() {
     const queryKey = 'maps';
     const queryClient = useQueryClient();
-    const { data, isLoading, error } = useQuery({ queryKey: [queryKey], queryFn: () => service.fetchList() });
+    const { data = [], isLoading, error } = useQuery({ queryKey: [queryKey], queryFn: () => service.fetchList() });
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [toBeDeteledId, setToBeDeletedId] = useState<string | null>(null);
     const [isAlertDialogOpen, setAlertDialogOpen] = useState(false);
@@ -115,7 +115,7 @@ export default function Page() {
                 <Grid item xs={12} md={12} lg={12}>
                     <MainCard>
                         <DetailedDataTable
-                            data={mapDataToTableFormat(data!, mapSpec.specification)}
+                            data={mapDataToTableFormat(data, mapSpec.specification)}
                             isSearchable={true}
                             pagination={true}
                             rowsPerPage={10}

--- a/client/src/components/Tables/DetailedDataTable.tsx
+++ b/client/src/components/Tables/DetailedDataTable.tsx
@@ -148,7 +148,6 @@ export default function DetailedDataTable({ data, selectedRows, isSearchable = f
 
     const isFiltered = searchTerm !== '';
 
-
     return (
         <Grid>
             <Grid container alignItems="center" justifyContent="space-between" sx={{ mb: '20px', height: '40px' }}>
@@ -226,20 +225,30 @@ export default function DetailedDataTable({ data, selectedRows, isSearchable = f
                             </TableRow>
                         </TableHead>
                         <TableBody>
-                            {sortedAndPaginatedRows.map((row) => (
+                            {data && Array.isArray(data) && data.length > 0 ? (
+                                sortedAndPaginatedRows.map((row) => (
+                                    <RowContent
+                                        key={row.id}
+                                        row={row}
+                                        isSelected={selected.includes(row.id)}
+                                        columns={data!.columns}
+                                        expandable={expandable}
+                                        onEdit={onEdit}
+                                        onDelete={onDelete}
+                                        onSelectionChanged={onSelectionChanged ? (() => handleClick(row.id)) : undefined}
+                                        customEvents={customEvents}
+                                        selectAll={selectAll}
+                                    />
+                                ))
+                            ) : (
                                 <RowContent
-                                    key={row.id}
-                                    row={row}
-                                    isSelected={selected.includes(row.id)}
-                                    columns={data!.columns}
-                                    expandable={expandable}
-                                    onEdit={onEdit}
-                                    onDelete={onDelete}
-                                    onSelectionChanged={onSelectionChanged ? (() => handleClick(row.id)) : undefined}
-                                    customEvents={customEvents}
-                                    selectAll={selectAll}
+                                    row={{ id: "-1", title: "No data available"}}
+                                    columns={[]}
+                                    isSelected={false}
+                                    expandable={false}
+                                    selectAll={false}
                                 />
-                            ))}
+                            )}
                         </TableBody>
                     </Table>
                 </TableContainer>

--- a/client/src/utils/mappers/toDataTable.ts
+++ b/client/src/utils/mappers/toDataTable.ts
@@ -5,6 +5,12 @@ export type Specification = {
 };
 
 export function mapDataToTableFormat(incomingData: any[], specification: Specification): TableData {
+  if (!incomingData || incomingData.length === 0) {
+    return {
+      columns: specification.columns,
+      rows: [],
+    };
+  }
   const rows: DataRow[] = incomingData.map((item) => mapRowToTableFormat(item, specification));
 
   return {


### PR DESCRIPTION
Fixes #9.

Removed the condition to only show the main card when there are mapinstances in the data response.

Please review @invit-dvd :)