### PR TITLE
Don't get server session if `AUTH_ENABLED=false`

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -10,7 +10,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const session = await getServerSession(authOptions);
+  const session = process.env.AUTH_ENABLED ? await getServerSession(authOptions) : null;
 
   return (
     <ReactQueryClientProvider>


### PR DESCRIPTION
Fixes #2. Is this a reasonable place to stop the client from making auth/session-related calls at startup?