### PR TITLE
Revert "Allow the `publishedMapMapper` to transform layers"

### DIFF
--- a/server/src/mappers/publishedMapMapper.ts
+++ b/server/src/mappers/publishedMapMapper.ts
@@ -94,11 +94,7 @@ export class publishedMapMapper
   toDBModel(dto: PublishedMapConfigDto, create?: boolean): DBPublishedMap {
     throw new Error("Method not implemented, not needed");
   }
-  toDto(model: DBPublishedMap, ...contexts: any[]): PublishedMapConfigDto {
-    const [sources = [], transformLayerIds = false] = contexts;
-    if (transformLayerIds) {
-      model.map.layers = transformLayers(model.map.layers as LayerDto[], false);
-    }
+  toDto(model: DBPublishedMap): PublishedMapConfigDto {
     return model.map as PublishedMapConfigDto;
   }
 }
@@ -213,8 +209,8 @@ function transformLayers(layerDtos: any[], publish: boolean = false): any[] {
     } = layer;
     const transformedLayer = {
       ...restOfLayer,
-      source: source.name || layer.source,
-      style: style.name || layer.style,
+      source: source.name,
+      style: style.name,
     };
     if (clusterStyle) {
       transformedLayer.clusterStyle = clusterStyle.name;

--- a/server/src/models/publishedMap.model.ts
+++ b/server/src/models/publishedMap.model.ts
@@ -1,6 +1,5 @@
 import mongoose, { Document } from "mongoose";
 import mongodb from "mongodb";
-import { PublishedMapConfigDto } from "@/shared/interfaces/dtos";
 
 interface DBPublishedMap extends Document {
   _id: mongodb.ObjectId;
@@ -9,7 +8,7 @@ interface DBPublishedMap extends Document {
   name: string;
   abstract: string;
   publishedDate: Date;
-  map: PublishedMapConfigDto;
+  map: Object;
 }
 
 const publishedMapSchema = new mongoose.Schema<DBPublishedMap>({

--- a/server/src/services/mapInstance.service.ts
+++ b/server/src/services/mapInstance.service.ts
@@ -16,7 +16,7 @@ import {
   InstanceToPublishedMapMapper,
   PreviewMapMapper,
   publishedMapListItemMapper,
-  publishedMapMapper
+  publishedMapMapper,
 } from "@/mappers/publishedMapMapper";
 import { instanceListItemMapper, instanceMapper } from "@/mappers/InstanceMapper";
 import { linkResourceMapper } from "@/mappers/";
@@ -105,13 +105,11 @@ class MapInstanceService {
 
   async getLatestPublished(name: string): Promise<PublishedMapConfigDto> {
     let response = await this.publishedRepository.query({ name: name }, { publishedDate: "desc" }, 1);
-    let dbSources = await this.linkResourceRepository.findAll();
-    return this.publishedMapMapper.toDto(response[0], dbSources, true);
+    return this.publishedMapMapper.toDto(response[0]);
   }
   async getPublished(id: string): Promise<PublishedMapConfigDto> {
     let response = await this.publishedRepository.find(id.replace(/\.json$/ig, ""));
-    let dbSources = await this.linkResourceRepository.findAll();
-    return this.publishedMapMapper.toDto(response, dbSources, true);
+    return this.publishedMapMapper.toDto(response);
   }
 
   async create(mapInstance: MapInstanceDto): Promise<MapInstanceDto> {


### PR DESCRIPTION
Reverts haninge-geodata/origo-admin#16.

In order to transform layers in published map configs, the server environment variable `PROXY_UPDATE_URL` should be empty - which means this PR is not needed and actually interferes with the proxy which needs the layers database IDs to remain.