### PR TITLE
Reverts "Revert "Allow the `publishedMapMapper` to transform layers""

### DIFF
--- a/server/src/mappers/publishedMapMapper.ts
+++ b/server/src/mappers/publishedMapMapper.ts
@@ -94,7 +94,11 @@ export class publishedMapMapper
   toDBModel(dto: PublishedMapConfigDto, create?: boolean): DBPublishedMap {
     throw new Error("Method not implemented, not needed");
   }
-  toDto(model: DBPublishedMap): PublishedMapConfigDto {
+  toDto(model: DBPublishedMap, ...contexts: any[]): PublishedMapConfigDto {
+    const [sources = [], transformLayerIds = false] = contexts;
+    if (transformLayerIds) {
+      model.map.layers = transformLayers(model.map.layers as LayerDto[], false);
+    }
     return model.map as PublishedMapConfigDto;
   }
 }
@@ -209,8 +213,8 @@ function transformLayers(layerDtos: any[], publish: boolean = false): any[] {
     } = layer;
     const transformedLayer = {
       ...restOfLayer,
-      source: source.name,
-      style: style.name,
+      source: source.name || layer.source,
+      style: style.name || layer.style,
     };
     if (clusterStyle) {
       transformedLayer.clusterStyle = clusterStyle.name;

--- a/server/src/models/publishedMap.model.ts
+++ b/server/src/models/publishedMap.model.ts
@@ -1,5 +1,6 @@
 import mongoose, { Document } from "mongoose";
 import mongodb from "mongodb";
+import { PublishedMapConfigDto } from "@/shared/interfaces/dtos";
 
 interface DBPublishedMap extends Document {
   _id: mongodb.ObjectId;
@@ -8,7 +9,7 @@ interface DBPublishedMap extends Document {
   name: string;
   abstract: string;
   publishedDate: Date;
-  map: Object;
+  map: PublishedMapConfigDto;
 }
 
 const publishedMapSchema = new mongoose.Schema<DBPublishedMap>({

--- a/server/src/services/mapInstance.service.ts
+++ b/server/src/services/mapInstance.service.ts
@@ -16,7 +16,7 @@ import {
   InstanceToPublishedMapMapper,
   PreviewMapMapper,
   publishedMapListItemMapper,
-  publishedMapMapper,
+  publishedMapMapper
 } from "@/mappers/publishedMapMapper";
 import { instanceListItemMapper, instanceMapper } from "@/mappers/InstanceMapper";
 import { linkResourceMapper } from "@/mappers/";
@@ -105,11 +105,13 @@ class MapInstanceService {
 
   async getLatestPublished(name: string): Promise<PublishedMapConfigDto> {
     let response = await this.publishedRepository.query({ name: name }, { publishedDate: "desc" }, 1);
-    return this.publishedMapMapper.toDto(response[0]);
+    let dbSources = await this.linkResourceRepository.findAll();
+    return this.publishedMapMapper.toDto(response[0], dbSources, true);
   }
   async getPublished(id: string): Promise<PublishedMapConfigDto> {
     let response = await this.publishedRepository.find(id.replace(/\.json$/ig, ""));
-    return this.publishedMapMapper.toDto(response);
+    let dbSources = await this.linkResourceRepository.findAll();
+    return this.publishedMapMapper.toDto(response, dbSources, true);
   }
 
   async create(mapInstance: MapInstanceDto): Promise<MapInstanceDto> {


### PR DESCRIPTION
Reverts the revert PR haninge-geodata/origo-admin#25 to reintroduce the code for allowing transformation of published maps. Seems most of it was needed after all. The interference with the proxy will be handled better in an upcoming fix.