### PR TITLE
Skip middleware handling when `AUTH_ENABLED=false`

### DIFF
--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -2,25 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
 
 export async function middleware(req: NextRequest) {
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const authEnabled = process.env.AUTH_ENABLED === "true";
   const publicPaths = ["/api/auth", "/login", "/signup"];
   const isPublicPath = publicPaths.some((path) => req.nextUrl.pathname.startsWith(path));
-  const authEnabled = process.env.PROTECTED_AUTH_ENABLED === undefined || process.env.PROTECTED_AUTH_ENABLED === "true";
 
   if (authEnabled && !isPublicPath) {
-    if (!token) {
-      const url = req.nextUrl.clone();
-      url.pathname = "/api/auth/signin";
-      return NextResponse.redirect(url);
-    }
+    const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
 
-    if (token.error === "RefreshAccessTokenError") {
+    if (!token || token.error === "RefreshAccessTokenError") {
       const url = req.nextUrl.clone();
       url.pathname = "/api/auth/signin";
       return NextResponse.redirect(url);
     }
   }
-
   return NextResponse.next();
 }
 


### PR DESCRIPTION
- Fixes the environment variable reference for `AUTH_ENABLED`
- When, `AUTH_ENABLED=false`; return without action
- Simplified the code a bit to avoid repetition