### PR TITLE
Exclude /gis path from body-parser middleware

### DIFF
--- a/proxy/src/server.ts
+++ b/proxy/src/server.ts
@@ -20,7 +20,14 @@ app.use(
 );
 
 app.use(cookieParser());
-app.use(bodyParser.json());
+app.use((req, res, next) => {
+  // Exclude the /gis path when using the body-parser middleware, so that the body will not
+  // already be consumed before passing it on to the target.
+  if (!req.url.startsWith(`${PROXY_BASE_PATH}/gis`)) {
+    bodyParser.json();
+  }
+  return next();
+});
 app.use(bodyParser.urlencoded({ extended: true }));
 
 const port = process.env.PORT || 3020;


### PR DESCRIPTION
Fixes #53.

The body-parser middleware used by the proxy consumes the ReadableStream that is the body sent in by a POST request. This means that it will not be passed on to the target URL along with the rest of the request.

This PR wraps the body-parser middleware in a middleware function that only activates the body-parser middleware if the request is for a path that doesn't start with /gis, since the body of such a request is not intended for the proxy itself but for the target.