### PR TITLE
Hide published URL from mapinstance list page

### DIFF
--- a/client/src/assets/specifications/tables/mapInstanceTableSpecification.json
+++ b/client/src/assets/specifications/tables/mapInstanceTableSpecification.json
@@ -42,12 +42,6 @@
                 "field": "isPublished",
                 "inputType": "checkbox",
                 "defaultValue": "false"
-            },
-            {
-                "headerName": "Publicerad Länk",
-                "field": "publishedUrl",
-                "inputType": "url",
-                "defaultValue": "false"
             }
         ]
     }


### PR DESCRIPTION
Fixes #36 together with #62.

Note that the published URL is still included in the mapinstances api endpoint as it might be useful there. It's just removed from the mapinstances table specification of the client.