### PR TITLE
Comment on published maps

### DIFF
--- a/client/src/api/mapInstanceService.ts
+++ b/client/src/api/mapInstanceService.ts
@@ -30,10 +30,10 @@ class MapInstanceService extends BaseApiService<MapInstanceDto> {
     });
   }
 
-  async publish(id: string): Promise<PublishedMapDto> {
+  async publish(id: string, comment: string | undefined): Promise<PublishedMapDto> {
     const restClient = await this.getRestClient();
     return this.executeWithEvents(async () => {
-      const response = await restClient.post<PublishedMapDto>(`${this.resourcePath}/${id}/publish`, {});
+      const response = await restClient.post<PublishedMapDto>(`${this.resourcePath}/${id}/publish`, { comment });
       return response;
     });
   }

--- a/client/src/app/maps/page.tsx
+++ b/client/src/app/maps/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Grid, Typography, Button, TextField } from "@mui/material";
+import { Grid, Typography, TextField } from "@mui/material";
 import MainCard from "@/components/Cards/MainCard/MainCard";
 import styles from "@/app/page.module.css";
 import { useRouter, usePathname } from "next/navigation";
@@ -9,6 +9,7 @@ import { mapDataToTableFormat } from "@/utils/mappers/toDataTable";
 import mapSpec from "@/assets/specifications/tables/mapInstanceTableSpecification.json";
 import DetailedDataTable from "@/components/Tables/DetailedDataTable";
 import FormDialog from "@/components/Dialogs/FormDialog";
+import PublishMapFormDialog from "@/components/Dialogs/PublishMapFormDialog";
 import { useEffect, useState } from "react";
 import { MapInstanceDto } from "@/shared/interfaces/dtos";
 import AlertDialog from "@/components/Dialogs/AlertDialog";
@@ -22,8 +23,8 @@ export default function Page() {
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [toBeDeteledId, setToBeDeletedId] = useState<string | null>(null);
     const [toBePublishedId, setToBePublishedId] = useState<string | null>(null);
-    const [isConfirmPublishDialogOpen, setConfirmPublishDialogOpen] = useState(false);
     const [isAlertDialogOpen, setAlertDialogOpen] = useState(false);
+    const [isPublishDialogOpen, setPublishDialogOpen] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const { showToast } = useApp();
     const [origoUrl, setOrigoUrl] = useState('');
@@ -87,19 +88,10 @@ export default function Page() {
     // Handle the publish mapinstance dialog
     const handlePublish = (id: string) => {
         setToBePublishedId(id);
-        setConfirmPublishDialogOpen(true);
+        setPublishDialogOpen(true);
     };
     const confirmPublish = async () => {
-        try {
-            let id = toBePublishedId!;
-            await service.publish(id);
-            queryClient.invalidateQueries({ queryKey: [queryKey] });
-            setConfirmPublishDialogOpen(false);
-            showToast('Kartinstansen publicerades!', 'success');
-        } catch (error) {
-            showToast('Ett fel inträffade, kunde inte publicera kartinstans', 'error');
-            console.error(error);
-        }
+        queryClient.invalidateQueries({ queryKey: [queryKey] });
     };
 
     const onSubmit = async (formData: FormData) => {
@@ -182,10 +174,12 @@ export default function Page() {
                             fullWidth
                             variant="standard"
                         />} />
+                    <PublishMapFormDialog
+                        open={isPublishDialogOpen} onClose={() => setPublishDialogOpen(false)} onConfirm={confirmPublish}
+                        id={toBePublishedId}
+                    />
                     <AlertDialog title="Bekräfta borttagning" contentText="Vänligen bekräfta borttagning av kartinstansen!"
                         open={isAlertDialogOpen} onClose={() => setAlertDialogOpen(false)} onConfirm={confirmDelete} />
-                    <AlertDialog title={`Publicera kartinstans?`} contentText={'Bekräfta publicering av kartinstans, detta kommer ersätta eventuellt existerande kartinstans!'}
-                        open={isConfirmPublishDialogOpen} onClose={() => setConfirmPublishDialogOpen(false)} onConfirm={confirmPublish} />
                 </Grid>
             </Grid>
         </main >

--- a/client/src/assets/specifications/tables/mapInstancePublishTableSpecification.json
+++ b/client/src/assets/specifications/tables/mapInstancePublishTableSpecification.json
@@ -16,8 +16,8 @@
                 "inputType": "textfield"
             },
             {
-                "headerName": "Beskrivning",
-                "field": "abstract",
+                "headerName": "Kommentar",
+                "field": "comment",
                 "inputType": "textfield"
             },
             {

--- a/client/src/components/Dialogs/AlertDialog.tsx
+++ b/client/src/components/Dialogs/AlertDialog.tsx
@@ -27,9 +27,7 @@ export default function AlertDialog({ open, title, contentText, onClose, onConfi
         {title}
       </DialogTitle>
       <DialogContent>
-        <DialogContentText id="alert-dialog-description"
-          dangerouslySetInnerHTML={{ __html: contentText }}>
-        </DialogContentText>
+        <DialogContentText id="alert-dialog-description">{contentText}</DialogContentText>
       </DialogContent>
       {onConfirm &&
         <DialogActions>

--- a/client/src/components/Dialogs/PublishMapFormDialog.tsx
+++ b/client/src/components/Dialogs/PublishMapFormDialog.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { useApp } from "@/contexts/AppContext";
+import AlertDialog from "@/components/Dialogs/AlertDialog";
+import FormDialog from "@/components/Dialogs/FormDialog";
+import { TextField } from "@mui/material";
+import { MapInstanceService as service } from '@/api';
+
+interface PublishMapFormDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    id: string | null;
+};
+
+export default function PublishMapFormDialog({ open, onClose, onConfirm, id }: PublishMapFormDialogProps) {
+    const [isConfirmPublishDialogOpen, setConfirmPublishDialogOpen] = useState(open);
+    const [publishComment, setPublishComment] = useState<string>();
+    const { showToast } = useApp();
+
+    const handleSubmitPublish = (formData: FormData) => {
+        setPublishComment(formData.get("comment")?.toString().trim());
+        onClose();
+        setConfirmPublishDialogOpen(true);
+    };
+
+    const handleConfirmPublish = async () => {
+        try {
+            await service.publish(id || "", publishComment);
+            showToast('Kartinstansen publicerades!', 'success');
+            setPublishComment(undefined);
+        } catch (error) {
+            showToast('Ett fel inträffade, kunde inte publicera kartinstans', 'error');
+            console.error(error);
+        }
+        onConfirm();
+        setConfirmPublishDialogOpen(false);
+    };
+
+    return (
+        <div>
+            <FormDialog title="Publicera kartinstans" contentText="Beskriv vad som är förändrat i kartinstansen sedan senaste publiceringen. Det ska gå att avgöra vilken som ska ompubliceras om en äldre fungerande version behöver återställas."
+                open={open} onClose={onClose}
+                onSubmit={handleSubmitPublish}
+                fieldToValidate="comment"
+                textField={<TextField
+                    autoFocus
+                    onChange={(e) => setPublishComment(e.target.value)}
+                    required
+                    defaultValue={publishComment}
+                    margin="dense"
+                    id="comment"
+                    name="comment"
+                    label="Kommentar - vad har ändrats?"
+                    type="text"
+                    fullWidth
+                    multiline
+                    rows={2}
+                    variant="filled"
+                />}
+            />
+            <AlertDialog title={`Publicera kartinstans?`}
+                contentText={`Bekräfta publicering av kartinstans, detta kommer ersätta eventuellt existerande kartinstans!`}
+                open={isConfirmPublishDialogOpen} onClose={() => setConfirmPublishDialogOpen(false)} onConfirm={handleConfirmPublish} />
+        </div>
+    );
+}

--- a/client/src/views/layers/LayersListingView.tsx
+++ b/client/src/views/layers/LayersListingView.tsx
@@ -159,7 +159,7 @@ export default function LayersListingView({ type, service, specification }: Laye
             {selectedLayer && <AlertDialog
                 open={isAlertDialogOpen}
                 onConfirm={confirmDelete}
-                contentText={`Vänligen bekräfta borttagning av ${selectedLayer.title} lagret!`}
+                contentText={`Vänligen bekräfta borttagning av lagret ${selectedLayer.title}!`}
                 onClose={() => setAlertDialogOpen(false)}
                 title="Bekräfta borttagning"
             />}

--- a/client/src/views/maps/Publish.tsx
+++ b/client/src/views/maps/Publish.tsx
@@ -5,6 +5,7 @@ import { MapInstanceService as service } from '@/api';
 import { mapDataToTableFormat } from "@/utils/mappers/toDataTable";
 import spec from "@/assets/specifications/tables/mapInstancePublishTableSpecification.json";
 import AlertDialog from "@/components/Dialogs/AlertDialog";
+import PublishMapFormDialog from "@/components/Dialogs/PublishMapFormDialog";
 import { useEffect, useState } from "react";
 import MainCard from "@/components/Cards/MainCard/MainCard";
 import envStore from "@/stores/Environment";
@@ -19,7 +20,7 @@ const Publish = ({ id }: PublishProps) => {
     const queryClient = useQueryClient();
     const queryKey = "list";
     const { data } = useQuery({ queryKey: [queryKey], queryFn: () => service.fetchPublishedList(id) });
-    const [isConfirmPublishDialogOpen, setConfirmPublishDialogOpen] = useState(false);
+    const [isPublishDialogOpen, setPublishDialogOpen] = useState(false);
     const [isConfirmRepublishDialogOpen, setConfirmRepublishDialogOpen] = useState(false);
     const [selectedInstance, setSelectedInstance] = useState<any>();
     const [origoUrl, setOrigoUrl] = useState('');
@@ -35,18 +36,10 @@ const Publish = ({ id }: PublishProps) => {
 
     // Handle the publish mapinstance dialog
     const handlePublish = () => {
-        setConfirmPublishDialogOpen(true);
+        setPublishDialogOpen(true);
     };
     const confirmPublish = async () => {
-        try {
-            await service.publish(id);
-            queryClient.invalidateQueries({ queryKey: [queryKey] });
-            setConfirmPublishDialogOpen(false);
-            showToast('Kartinstansen publicerades!', 'success');
-        } catch (error) {
-            showToast('Ett fel inträffade, kunde inte publicera kartinstans', 'error');
-            console.error(error);
-        }
+        queryClient.invalidateQueries({ queryKey: [queryKey] });
     };
 
     // Handle the republish previously published map dialog
@@ -118,8 +111,10 @@ const Publish = ({ id }: PublishProps) => {
                     </>}
                 </MainCard>
             </Grid>
-            <AlertDialog title={`Publicera kartinstans?`} contentText={'Bekräfta publicering av kartinstans, detta kommer ersätta eventuellt existerande kartinstans!'}
-                open={isConfirmPublishDialogOpen} onClose={() => setConfirmPublishDialogOpen(false)} onConfirm={confirmPublish} />
+            <PublishMapFormDialog
+                open={isPublishDialogOpen} onClose={() => setPublishDialogOpen(false)} onConfirm={confirmPublish}
+                id={id}
+            />
             <AlertDialog title="Ompublicera kartinstans" contentText={`Är du säker på att du vill ompublicera kartinstansen "${selectedInstance?.title}"?`}
                 open={isConfirmRepublishDialogOpen} onClose={() => setConfirmRepublishDialogOpen(false)} onConfirm={confirmRepublish} />
         </Box>

--- a/server/src/controllers/MapInstanceController.ts
+++ b/server/src/controllers/MapInstanceController.ts
@@ -51,7 +51,8 @@ class ExtendedMapInstanceController extends BaseController<MapInstanceService> {
   async publish(req: Request, res: Response): Promise<void> {
     try {
       const id = req.params.id;
-      const publishedMap = (await (this.service as any).publish(id)) as PublishedMapDto;
+      const comment: string = req.body.comment;
+      const publishedMap = (await (this.service as any).publish(id, comment)) as PublishedMapDto;
       res.json(publishedMap);
     } catch (error) {
       this.handleError(res, error);

--- a/server/src/mappers/publishedMapMapper.ts
+++ b/server/src/mappers/publishedMapMapper.ts
@@ -20,9 +20,9 @@ export class publishedMapListItemMapper
   toDto(model: DBPublishedMap): PublishedMapListItemDto {
     return {
       id: model.id,
+      comment: model.comment,
       title: model.title,
       name: model.name,
-      abstract: model.abstract,
       publishedDate: convertDateToSwedishTime(model.publishedDate),
       url: `${process.env.MAPINSTANCE_ROUTE_PATH}/published/${model.id}`,
     };
@@ -44,9 +44,10 @@ export class InstanceToPublishedMapMapper
   toDto(model: DBPublishedMap): DBMapInstance {
     throw new Error("Method not implemented, not needed");
   }
-  toDBModel(model: DBMapInstance, ...contexts: any[]): DBPublishedMap {
+  toDBModel(model: DBMapInstance, comment: string, ...contexts: any[]): DBPublishedMap {
     const [sources = []] = contexts;
     const publishedModel: Partial<DBPublishedMap> = {
+      comment,
       mapInstanceId: model._id,
       title: model.title,
       name: model.name,

--- a/server/src/models/publishedMap.model.ts
+++ b/server/src/models/publishedMap.model.ts
@@ -4,6 +4,7 @@ import { PublishedMapConfigDto } from "@/shared/interfaces/dtos";
 
 interface DBPublishedMap extends Document {
   _id: mongodb.ObjectId;
+  comment?: string;
   mapInstanceId: mongodb.ObjectId;
   title: string;
   name: string;
@@ -14,6 +15,7 @@ interface DBPublishedMap extends Document {
 
 const publishedMapSchema = new mongoose.Schema<DBPublishedMap>({
   title: { type: String, required: true },
+  comment: { type: String, required: false },
   mapInstanceId: { type: mongoose.Schema.Types.ObjectId, required: true },
   publishedDate: { type: Date, required: true },
   name: { type: String, required: true },

--- a/server/src/routes/MapInstanceRoutes.ts
+++ b/server/src/routes/MapInstanceRoutes.ts
@@ -71,7 +71,6 @@ router.post(`/${route}`, (req, res) => controller.create(req, res));
  * @route POST /${route}/:id/publish
  * @description Publish a specific map instance
  * @param {string} id - The map instance ID
- * @request {MapInstanceDto} requestBody - The map instance data to publish
  * @returns {PublishedMapListItemDto}
  */
 router.post(`/${route}/:id/publish`, (req, res) =>

--- a/server/src/routes/MapInstanceRoutes.ts
+++ b/server/src/routes/MapInstanceRoutes.ts
@@ -71,6 +71,7 @@ router.post(`/${route}`, (req, res) => controller.create(req, res));
  * @route POST /${route}/:id/publish
  * @description Publish a specific map instance
  * @param {string} id - The map instance ID
+ * @request {} requestBody - Set the comment in the body: { comment: "My comment string." }
  * @returns {PublishedMapListItemDto}
  */
 router.post(`/${route}/:id/publish`, (req, res) =>

--- a/server/src/routes/MapInstanceRoutes.ts
+++ b/server/src/routes/MapInstanceRoutes.ts
@@ -72,7 +72,7 @@ router.post(`/${route}`, (req, res) => controller.create(req, res));
  * @description Publish a specific map instance
  * @param {string} id - The map instance ID
  * @request {MapInstanceDto} requestBody - The map instance data to publish
- * @returns {MapInstanceDto}
+ * @returns {PublishedMapListItemDto}
  */
 router.post(`/${route}/:id/publish`, (req, res) =>
   controller.publish(req, res)
@@ -83,7 +83,7 @@ router.post(`/${route}/:id/publish`, (req, res) =>
  * @description Republish a specific version of a map instance
  * @param {string} id - The map instance ID
  * @param {string} instanceId - The specific instance ID to republish
- * @returns {PublishedMapConfigDto}
+ * @returns {PublishedMapListItemDto}
  */
 router.post(`/${route}/:id/republish/:instanceId`, (req, res) =>
   controller.republish(req, res)

--- a/server/src/services/mapInstance.service.ts
+++ b/server/src/services/mapInstance.service.ts
@@ -72,7 +72,7 @@ class MapInstanceService {
     return this.previewMapMapper.toDto(response, sources);
   }
 
-  async publish(id: string): Promise<PublishedMapConfigDto> {
+  async publish(id: string): Promise<PublishedMapListItemDto> {
     let mapInstance = await this.repository.find(id);
     if (!mapInstance) throw new Error("Map instance not found");
 
@@ -81,10 +81,10 @@ class MapInstanceService {
     let publishedMap = this.instanceToPublishedMapMapper.toDBModel(mapInstance, sources);
 
     let response = await this.publishedRepository.create(publishedMap);
-    return this.publishedMapMapper.toDto(response, { publish: true });
+    return this.publishedMapListItemMapper.toDto(response);
   }
 
-  async republish(id: string, instanceId: string): Promise<PublishedMapConfigDto> {
+  async republish(id: string, instanceId: string): Promise<PublishedMapListItemDto> {
     let publishedMap = await this.publishedRepository.find(instanceId);
     if (!publishedMap) throw new Error("Map instance not found");
     if (publishedMap.mapInstanceId.toString() !== id) throw new Error("Map instance id does not match!");
@@ -95,7 +95,7 @@ class MapInstanceService {
     republishedMap._id = new mongoose.Types.ObjectId();
 
     let response = await this.publishedRepository.create(republishedMap);
-    return this.publishedMapMapper.toDto(response, { publish: true });
+    return this.publishedMapListItemMapper.toDto(response);
   }
 
   async getPublishedList(id: string): Promise<PublishedMapListItemDto[]> {

--- a/server/src/services/mapInstance.service.ts
+++ b/server/src/services/mapInstance.service.ts
@@ -6,7 +6,7 @@ import {
   MapInstanceDto,
   MapInstanceListItemDto,
   PublishedMapConfigDto,
-  PublishedMapListItemDto,
+  PublishedMapListItemDto
 } from "@/shared/interfaces/dtos";
 import { DBPublishedMap, PublishedMapModel } from "@/models/publishedMap.model";
 import mongoose from "mongoose";
@@ -72,13 +72,13 @@ class MapInstanceService {
     return this.previewMapMapper.toDto(response, sources);
   }
 
-  async publish(id: string): Promise<PublishedMapListItemDto> {
+  async publish(id: string, comment: string): Promise<PublishedMapListItemDto> {
     let mapInstance = await this.repository.find(id);
     if (!mapInstance) throw new Error("Map instance not found");
 
     let dbSources = await this.linkResourceRepository.findAll();
     let sources = dbSources.map((item) => this._linkResourceMapper.toDto(item));
-    let publishedMap = this.instanceToPublishedMapMapper.toDBModel(mapInstance, sources);
+    let publishedMap = this.instanceToPublishedMapMapper.toDBModel(mapInstance, comment, sources);
 
     let response = await this.publishedRepository.create(publishedMap);
     return this.publishedMapListItemMapper.toDto(response);

--- a/shared/interfaces/dtos/MapInstanceDto.ts
+++ b/shared/interfaces/dtos/MapInstanceDto.ts
@@ -36,6 +36,7 @@ export interface PublishedMapDto extends PublishedMapBaseDto {
 
 export interface PublishedMapBaseDto {
   id: string;
+  comment?: string;
   title: string;
   name: string;
   abstract: string;
@@ -46,9 +47,9 @@ export interface PublishedMapBaseDto {
 
 export interface PublishedMapListItemDto {
   id: string;
+  comment?: string;
   title: string;
   name: string;
-  abstract: string;
   publishedDate: string;
   url: string;
 }


### PR DESCRIPTION
Fixes #67.

Adds the possibility (actually mandatory) to add a comment when publishing a map and displays it in the published map list. 

Adds a PublishMapFormDialog that is reused in the quick action from the map instances list and in the published map list.

Also removes an unsecure but unnecessary call to `dangerouslySetInnerHTML` in the AlertDialog and adds some minor text polishing.