### PR TITLE
Fall back to using name in preview route if id is not a valid ObjectId

### DIFF
--- a/server/src/routes/MapInstanceRoutes.ts
+++ b/server/src/routes/MapInstanceRoutes.ts
@@ -6,8 +6,8 @@ const router = createSecureRouter(route);
 
 /**
  * @route GET /${route}/:id/preview
- * @description Get a preview of a specific map instance
- * @param {string} id - The map instance ID
+ * @description Get a preview of a specific map instance by its id or name.
+ * @param {string} id - The map instance ID or name
  * @returns {PublishedMapConfigDto}
  */
 router.get(`/${route}/:id/preview(\.json)?`, (req, res) =>

--- a/server/src/services/mapInstance.service.ts
+++ b/server/src/services/mapInstance.service.ts
@@ -65,7 +65,12 @@ class MapInstanceService {
   }
 
   async getPreview(id: string): Promise<PublishedMapConfigDto> {
-    let response = await this.repository.find(id);
+    let response;
+    if (mongoose.Types.ObjectId.isValid(id)) {
+      response = await this.repository.find(id);
+    } else {
+      response = (await this.repository.findByCriteria({ name: id }))[0];
+    }
     let dbSources = await this.linkResourceRepository.findAll();
     let sources = dbSources.map((item) => this._linkResourceMapper.toDto(item));
 


### PR DESCRIPTION
Fixes #79.

When getting a mapinstance preview, if the id parameter does not validate to a Mongoose ObjectId, it will try to return a mapinstance preview with a matching name property instead, e g `GET /mapinstances/mymapinstancename/preview`.