### PR TITLE
New API route `GET /media/upload/:id`

### DIFF
--- a/server/src/controllers/MediaController.ts
+++ b/server/src/controllers/MediaController.ts
@@ -26,6 +26,16 @@ class MediaController {
       this.handleError(res, error);
     }
   }
+
+  async getByIdOrFilename(req: Request, res: Response) {
+    try {
+      const item = await this.service.getFileByIdOrFilename(req.params.id);
+      res.status(200).json(item);
+    } catch (error) {
+      this.handleError(res, error);
+    }
+  }
+
   async upload(req: Request, res: Response) {
     const multerReq = req as MulterRequest;
     if (multerReq.files && Array.isArray(multerReq.files)) {
@@ -37,7 +47,7 @@ class MediaController {
       res.status(200).json(createdFiles);
     } else {
       res.status(400).json({
-        message: "Inga filer uppladdade eller filtypen är inte tillåten",
+        message: "No files were uploaded",
       });
     }
   }
@@ -48,7 +58,7 @@ class MediaController {
       let file = await this.service.deleteFile(id);
       res
         .status(200)
-        .json({ message: "Ikonen har tagits bort framgångsrikt", file: file });
+        .json({ message: "Media file and registration successfully removed", file: file });
     } catch (error) {
       this.handleError(res, error);
     }
@@ -57,7 +67,7 @@ class MediaController {
     if (error instanceof Error) {
       res.status(500).json({ error: error.message });
     } else {
-      res.status(500).json({ error: "Ett oväntat fel inträffade" });
+      res.status(500).json({ error: "Unexpected error" });
     }
   }
 }

--- a/server/src/interfaces/uploadservice.interface.ts
+++ b/server/src/interfaces/uploadservice.interface.ts
@@ -2,6 +2,7 @@ import { MediaDto } from "@/shared/interfaces/dtos";
 
 export interface IUploadService {
   getAllFiles(): Promise<MediaDto[]>;
+  getFileByIdOrFilename(id: string): Promise<MediaDto>;
   getMulterConfig(): any;
   saveFiles(files: Express.Multer.File[]): Promise<MediaDto[]>;
   deleteFile(id: string): Promise<void>;

--- a/server/src/routes/MediaRoutes.ts
+++ b/server/src/routes/MediaRoutes.ts
@@ -2,34 +2,42 @@ import { getUpload } from "@/services/upload-factory";
 import { MediaController as controller } from "../controllers";
 import { createSecureRouter, RouteRegistry } from "@/utils/routeUtils";
 
-const route = "media/upload";
+const route = "media";
 const upload = getUpload();
 const router = createSecureRouter(route);
 
 /**
- * @route GET /${route}/
- * @description Get all media files
+ * @route GET /${route}/upload/
+ * @description Get all media file registrations
  * @returns {MediaDto[]}
  */
-router.get(`/${route}/`, (req, res) => controller.getAll(req, res));
+router.get(`/${route}/upload`, (req, res) => controller.getAll(req, res));
 
 /**
- * @route POST /${route}/
+ * @route GET /${route}/upload/:id
+ * @description Get a specific media file registration by id or filename
+ * @param {string} id - The media file ID
+ * @returns {MediaDto}
+ */
+router.get(`/${route}/upload/:id`, (req, res) => controller.getByIdOrFilename(req, res));
+
+/**
+ * @route POST /${route}/upload/
  * @description Upload media file(s)
  * @request {request} requestBody - The media file(s) to upload
  * @returns {MediaDto[]}
  */
-router.post(`/${route}/`, upload.any(), (req, res) => {
+router.post(`/${route}/upload/`, upload.any(), (req, res) => {
   controller.upload(req, res);
 });
 
 /**
- * @route DELETE /${route}/:id
- * @description Delete a specific media file
+ * @route DELETE /${route}/upload/:id
+ * @description Delete a specific media file and its registration
  * @param {string} id - The media file ID
  * @returns {MediaDto}
  */
-router.delete(`/${route}/:id`, (req, res) => controller.deleteById(req, res));
+router.delete(`/${route}/upload/:id`, (req, res) => controller.deleteById(req, res));
 
 RouteRegistry.registerRoutes(router, route);
 export default router;

--- a/server/src/services/azure-upload.service.ts
+++ b/server/src/services/azure-upload.service.ts
@@ -28,7 +28,17 @@ class AzureUploadService implements IUploadService {
       return files.map((file) => mapDBMediaToMediaDto(file, this.uploadPath));
     } catch (error) {
       console.error(`[${new Date().toISOString()}] ${error}`);
-      throw new Error("Det gick inte att hämta filerna");
+      throw new Error("Unable to get media registrations");
+    }
+  }
+
+  async getFileByIdOrFilename(id: string): Promise<MediaDto> {
+    try {
+      const file = (await this.repository.query({ $or: [ { _id: id }, { filename: id } ] }, null, 1))[0];
+      return mapDBMediaToMediaDto(file, this.uploadPath);
+    } catch (error) {
+      console.error(`[${new Date().toISOString()}] ${error}`);
+      throw new Error("Unable to get the media registration");
     }
   }
 

--- a/server/src/services/local-upload.service.ts
+++ b/server/src/services/local-upload.service.ts
@@ -11,7 +11,6 @@ import { IUploadService } from "@/interfaces/uploadservice.interface";
 
 const UPLOAD_FOLDER = process.env.UPLOAD_FOLDER!;
 class LocalUploadService implements IUploadService {
-  private uploadFolder = UPLOAD_FOLDER;
   private uploadUrl = "";
   private repository: Repository<DBMedia>;
 
@@ -26,7 +25,17 @@ class LocalUploadService implements IUploadService {
       return files.map((file) => mapDBMediaToMediaDto(file, this.uploadUrl));
     } catch (error) {
       console.error(`[${new Date().toISOString()}] ${error}`);
-      throw new Error("Det gick inte att hämta filerna");
+      throw new Error("Unable to get media registrations");
+    }
+  }
+
+  async getFileByIdOrFilename(id: string): Promise<MediaDto> {
+    try {
+      const file = (await this.repository.query({ $or: [ { _id: id }, { filename: id } ] }, null, 1))[0];
+      return mapDBMediaToMediaDto(file, this.uploadUrl);
+    } catch (error) {
+      console.error(`[${new Date().toISOString()}] ${error}`);
+      throw new Error("Unable to get the media registration");
     }
   }
 


### PR DESCRIPTION
Fixes #101.

Adds a new API route `GET /media/upload/:id` to get a specific media file registration by id or filename.

Also changes the _base route_ to `/media` instead of `/media/upload` to make room for future routes under `/media`. All current routes as well as the new one are still found under `/media/upload`.