### PR TITLE
Support any file type in media uploads

### DIFF
--- a/client/src/components/Selects/MediaSelector.tsx
+++ b/client/src/components/Selects/MediaSelector.tsx
@@ -1,11 +1,13 @@
 import { MediaDto } from "@/shared/interfaces/dtos";
 import { Box, Button, Grid, InputAdornment, TextField, Tooltip, Typography, styled } from "@mui/material";
 import { useEffect, useState } from "react";
-import { Folder as FolderIcon,
+import {
     CloudUpload as CloudUploadIcon,
     CreateNewFolder as CreateNewFolderIcon,
     Delete as DeleteIcon,
+    DescriptionRounded as DocumentIcon,
     Edit as EditIcon,
+    Folder as FolderIcon,
     Search as SearchIcon
 } from '@mui/icons-material';
 import { useQueryClient, useQuery } from "@tanstack/react-query";
@@ -134,9 +136,9 @@ export const MediaSelector = ({ onMediaSelect, maxHeight = 800, minHeight = 350,
         try {
             await service.upload(files, currentPath);
             queryClient.invalidateQueries({ queryKey: [queryKey, currentPath] });
-            showToast('Ikonen har laddats upp', 'success');
+            showToast('Filen har laddats upp', 'success');
         } catch (error) {
-            showToast('Ikonen kunde inte laddas upp', 'error');
+            showToast('Filen kunde inte laddas upp', 'error');
             console.error(`[${new Date().toISOString()}] Error when uploading files: ${error}`);
         }
     };
@@ -186,14 +188,14 @@ export const MediaSelector = ({ onMediaSelect, maxHeight = 800, minHeight = 350,
                     showToast('Mappen har raderats', 'success');
                 } else {
                     await service.deleteFile(selectedMedia.id!);
-                    showToast('Ikonen har raderats', 'success');
+                    showToast('Filen har raderats', 'success');
                 }
                 queryClient.invalidateQueries({ queryKey: [queryKey, currentPath] });
                 setselectedMedia(null as unknown as MediaDto);
                 setAlertDialogOpen(false);
             } catch (error) {
-                showToast(`Kunde inte radera ${selectedMedia.fieldname === 'folders' ? 'mappen' : 'ikonen'}.`, 'error');
-                console.error(`[${new Date().toISOString()}] Error deleting the icon: ${error}`);
+                showToast(`Kunde inte radera ${selectedMedia.fieldname === 'folders' ? 'mappen' : 'filen'}.`, 'error');
+                console.error(`[${new Date().toISOString()}] Error deleting the file: ${error}`);
                 setAlertDialogOpen(false);
             }
         }
@@ -239,7 +241,7 @@ export const MediaSelector = ({ onMediaSelect, maxHeight = 800, minHeight = 350,
     return (
         <Grid item xs={12} sx={{ border: '1px solid #E0E0E0' }}>
             <Box component="div" sx={{ borderBottom: '1px solid #E0E0E0', backgroundColor: '#fbfafa', height: '56px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                <Typography variant="h5" sx={{ ml: '10px', textTransform: 'uppercase' }} >Ikoner</Typography>
+                <Typography variant="h5" sx={{ ml: '10px', textTransform: 'uppercase' }} >Uppladdade filer</Typography>
                 <Box component="div" >
                     <Tooltip title="Skapa ny mapp">
                         <span>
@@ -398,7 +400,17 @@ export const MediaSelector = ({ onMediaSelect, maxHeight = 800, minHeight = 350,
                                             border: selectedMedia && selectedMedia.id === item.id ? '2px solid #1890ff' : 'none',
                                             boxShadow: selectedMedia && selectedMedia.id === item.id ? '0 0 10px #1890ff, 0 0 6px #1890ff80' : 'none'
                                         }}
-                                    /> : null
+                                    /> :
+                                    <DocumentIcon onClick={() => handleMediaSelection(item)}
+                                      style={{
+                                        width: '48px',
+                                        height: '48px',
+                                        borderRadius: '50%',
+                                        cursor: 'pointer',
+                                        color: 'rgba(0, 0, 0, 0.54)',
+                                        border: selectedMedia && selectedMedia.id === item.id ? '2px solid #1890ff' : 'none',
+                                        boxShadow: selectedMedia && selectedMedia.id === item.id ? '0 0 10px #1890ff, 0 0 6px #1890ff80' : 'none'
+                                    }}/>
                             }
                             <Typography variant="body2" sx={{ mt: 1 }}>
                                 {formatName(item.name, 20)}
@@ -418,7 +430,7 @@ export const MediaSelector = ({ onMediaSelect, maxHeight = 800, minHeight = 350,
                                         <Typography variant="h6" sx={{ mt: 1 }}>Filtyp: {selectedMedia.fieldname === 'folders' ? 'mapp' : selectedMedia.mimetype}</Typography>
                                     </Box>
                                 </>
-                            ) : <Typography sx={{ p: 2 }}>Välj en ikon för att visa information.</Typography>}
+                            ) : <Typography sx={{ p: 2 }}>Välj en fil för att visa information.</Typography>}
                         </Box>
                     </Grid>
                 )}

--- a/server/.env.template
+++ b/server/.env.template
@@ -7,6 +7,7 @@ DATABASE='mongodb://{usr}:{pwd}@{url}/origoadmin' # Database connection string
 
 UPLOAD_FOLDER='C:\\uploads' # Folder for uploaded files, so for example will be src/uploads
 UPLOAD_URL="http://{url}/uploads" # URL for uploaded files, used when retrieving list of files from the api
+UPLOAD_MAX_FILESIZE=100000000 # Maximum allowed file size of files uploaded through the POST /media/upload API endpoint
 MAPINSTANCE_ROUTE_PATH='http://{url}/api/mapinstances' # URL for the mapinstances api, used as the first part of the publishedUrl property when retrieving list of mapinstances from the api. Should point to the proxy if using proxy authentication
 USE_AZURE_STORAGE=false # Use Azure storage for uploaded files
 TOKEN_SECRET='{token_secret}' # Secret for the JWT token, Generate this with npm run generate-secret-key in the server folder

--- a/server/src/services/azure-upload.service.ts
+++ b/server/src/services/azure-upload.service.ts
@@ -13,6 +13,7 @@ dotevnv.config();
 const AZURE_STORAGE_CONNECTION_STRING =
   process.env.AZURE_STORAGE_CONNECTION_STRING!;
 const AZURE_CONTAINER_NAME = process.env.AZURE_CONTAINER_NAME!;
+const UPLOAD_MAX_FILESIZE = parseInt(process.env.UPLOAD_MAX_FILESIZE as string) || 100000000;
 
 class AzureUploadService implements IUploadService {
   private uploadPath = process.env.UPLOAD_PATH!;
@@ -143,7 +144,7 @@ class AzureUploadService implements IUploadService {
       storage: storage,
       fileFilter: fileFilter,
       limits: {
-        fileSize: 100000000,
+        fileSize: UPLOAD_MAX_FILESIZE,
       },
     };
   };
@@ -156,12 +157,15 @@ const fileFilter = (
   req: Request,
   file: Express.Multer.File,
   callback: multer.FileFilterCallback
-) => {
+) => callback(null, true);
+/** The filter function can be used to restrict which files are allowed.
+{
   if (file.mimetype.startsWith("image/")) {
     callback(null, true);
   } else {
     callback(null, false);
   }
 };
+ */
 
 export { AzureUploadService };

--- a/server/src/services/local-upload.service.ts
+++ b/server/src/services/local-upload.service.ts
@@ -10,6 +10,7 @@ import { MediaDto } from "@/shared/interfaces/dtos";
 import { IUploadService } from "@/interfaces/uploadservice.interface";
 
 const UPLOAD_FOLDER = process.env.UPLOAD_FOLDER!;
+const UPLOAD_MAX_FILESIZE = parseInt(process.env.UPLOAD_MAX_FILESIZE as string) || 100000000;
 class LocalUploadService implements IUploadService {
   private uploadUrl = "";
   private repository: Repository<DBMedia>;
@@ -190,7 +191,7 @@ class LocalUploadService implements IUploadService {
       storage: storage,
       fileFilter: fileFilter,
       limits: {
-        fileSize: 100000000,
+        fileSize: UPLOAD_MAX_FILESIZE,
       },
     };
   };
@@ -219,12 +220,15 @@ const fileFilter = (
   req: Request,
   file: Express.Multer.File,
   callback: multer.FileFilterCallback
-) => {
+) => callback(null, true);
+/** The filter function can be used to restrict which files are allowed.
+  {
   if (file.mimetype.startsWith("image/")) {
     callback(null, true);
   } else {
     callback(null, false);
   }
 };
+ */
 
 export { LocalUploadService };


### PR DESCRIPTION
Fixes #109.

Images mime types other than image/* will be displayed using a generic file icon. The API now accepts any type of file up to a default file size of 100 MB.

Also adds a new environment variable to the server, to change the maximum uploaded file size: `UPLOAD_MAX_FILESIZE`